### PR TITLE
ezpkg: coop: add coop ezbuild v1.2.3

### DIFF
--- a/repo/main/coop/coop-1.2.3.ezbuild
+++ b/repo/main/coop/coop-1.2.3.ezbuild
@@ -1,0 +1,6 @@
+inherit meson
+
+src=(
+    https://github.com/mojyack/coop.git
+)
+git_coop_commit=v$ver


### PR DESCRIPTION
need coop >= 1.2.3 to build [netprotocol](https://github.com/mojyack/netprotocol/commit/7c1c986850a6e046c5cc801ad6669f3cad8a298c)